### PR TITLE
Support for Vivaldi

### DIFF
--- a/workflow/browser_tabs.rb
+++ b/workflow/browser_tabs.rb
@@ -23,7 +23,8 @@ module BrowserTabs
         'WebKit',
         'Google Chrome',
         'Google Chrome Canary',
-        'Chromium'
+        'Chromium',
+        'Vivaldi'
       ]
     end
 


### PR DESCRIPTION
[Vivaldi](https://vivaldi.com/) is a Chromium based browser.
It works well with just extending the list.