### PR TITLE
Support for Brave Browser Beta

### DIFF
--- a/workflow/browser_tabs.rb
+++ b/workflow/browser_tabs.rb
@@ -23,7 +23,8 @@ module BrowserTabs
         'WebKit',
         'Google Chrome',
         'Google Chrome Canary',
-        'Chromium'
+        'Chromium',
+        'Brave Browser Beta'
       ]
     end
 


### PR DESCRIPTION
Brave Browser Beta is Chromium based, looks to be running without issue by simply adding it to the list